### PR TITLE
Introducing new KnowMagic

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -578,7 +578,7 @@ dependencies = [
 
 [[package]]
 name = "rain_cli_meta"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "ciborium",

--- a/cli/src/cli/build.rs
+++ b/cli/src/cli/build.rs
@@ -86,14 +86,14 @@ impl TryFrom<&BuildItem> for RainMetaDocumentV1Item {
 
 impl BuildItem {
     /// Write a BuildItem to a byte buffer as normalized, encoded cbor rain meta.
-    fn write<W: std::io::Write>(&self, writer: &mut W) -> anyhow::Result<()> {
+    pub fn write<W: std::io::Write>(&self, writer: &mut W) -> anyhow::Result<()> {
         Ok(ciborium::into_writer(&RainMetaDocumentV1Item::try_from(self)?, writer)?)
     }
 }
 
 /// Build a rain meta document from a sequence of BuildItems.
-fn build_bytes(magic: KnownMagic, items: Vec<BuildItem>) -> anyhow::Result<Vec<u8>> {
-    let mut bytes: Vec<u8> = magic.to_prefix_bytes().to_vec();
+pub fn build_bytes(magic: KnownMagic, items: Vec<BuildItem>) -> anyhow::Result<Vec<u8>> {
+    let mut bytes: Vec<u8> = magic.to_prefix_bytes().to_vec(); 
     for item in items {
         item.write(&mut bytes)?;
     }

--- a/cli/src/cli/schema/show.rs
+++ b/cli/src/cli/schema/show.rs
@@ -26,6 +26,7 @@ pub fn show(s: Show) -> anyhow::Result<()> {
         KnownMeta::SolidityAbiV2 => schema_for!(crate::meta::solidity_abi::v2::SolidityAbi),
         KnownMeta::InterpreterCallerMetaV1 => schema_for!(crate::meta::interpreter_caller::v1::InterpreterCallerMeta),
         KnownMeta::OpV1 => schema_for!(crate::meta::op::v1::OpMeta),
+        _ => anyhow::bail!("Schema not supported for {}", s.schema),
     };
 
     let schema_string = if s.pretty_print {

--- a/cli/src/meta/magic.rs
+++ b/cli/src/meta/magic.rs
@@ -10,7 +10,7 @@ pub enum KnownMagic {
     SolidityAbiV2 = 0xffe5ffb4a3ff2cde,
     OpMetaV1 = 0xffe5282f43e495b4,
     InterpreterCallerMetaV1 = 0xffc21bbf86cc199b,
-    OptionalMeta = 0xff0c949e41995247
+    OptionalMetaV1 = 0xff0c949e41995247
 }
 
 impl KnownMagic {
@@ -54,5 +54,13 @@ mod tests {
         let magic_number_after_prefix = magic_number.to_prefix_bytes();
 
         assert_eq!(hex::encode(magic_number_after_prefix), "ffc21bbf86cc199b");
+    }
+
+    #[test]
+    fn test_optional_meta_v1() {
+        let magic_number = KnownMagic::OptionalMetaV1;
+        let magic_number_after_prefix = magic_number.to_prefix_bytes();
+
+        assert_eq!(hex::encode(magic_number_after_prefix), "ff0c949e41995247");
     }
 }

--- a/cli/src/meta/magic.rs
+++ b/cli/src/meta/magic.rs
@@ -10,6 +10,7 @@ pub enum KnownMagic {
     SolidityAbiV2 = 0xffe5ffb4a3ff2cde,
     OpMetaV1 = 0xffe5282f43e495b4,
     InterpreterCallerMetaV1 = 0xffc21bbf86cc199b,
+    OptionalMeta = 0xff0c949e41995247
 }
 
 impl KnownMagic {

--- a/cli/src/meta/mod.rs
+++ b/cli/src/meta/mod.rs
@@ -16,7 +16,7 @@ pub enum KnownMeta {
     SolidityAbiV2,
     InterpreterCallerMetaV1,
     OpV1,
-    OptionalMeta
+    OptionalMetaV1
 }
 
 impl TryFrom<KnownMagic> for KnownMeta {
@@ -26,7 +26,7 @@ impl TryFrom<KnownMagic> for KnownMeta {
             KnownMagic::SolidityAbiV2 => Ok(KnownMeta::SolidityAbiV2),
             KnownMagic::InterpreterCallerMetaV1 => Ok(KnownMeta::InterpreterCallerMetaV1),
             KnownMagic::OpMetaV1 => Ok(KnownMeta::OpV1),
-            KnownMagic::OptionalMeta => Ok(KnownMeta::OptionalMeta),
+            KnownMagic::OptionalMetaV1 => Ok(KnownMeta::OptionalMetaV1),
             _ => Err(anyhow::anyhow!("Unsupported magic {}", magic)),
         }
     }

--- a/cli/src/meta/mod.rs
+++ b/cli/src/meta/mod.rs
@@ -16,6 +16,7 @@ pub enum KnownMeta {
     SolidityAbiV2,
     InterpreterCallerMetaV1,
     OpV1,
+    OptionalMeta
 }
 
 impl TryFrom<KnownMagic> for KnownMeta {
@@ -25,6 +26,7 @@ impl TryFrom<KnownMagic> for KnownMeta {
             KnownMagic::SolidityAbiV2 => Ok(KnownMeta::SolidityAbiV2),
             KnownMagic::InterpreterCallerMetaV1 => Ok(KnownMeta::InterpreterCallerMetaV1),
             KnownMagic::OpMetaV1 => Ok(KnownMeta::OpV1),
+            KnownMagic::OptionalMeta => Ok(KnownMeta::OptionalMeta),
             _ => Err(anyhow::anyhow!("Unsupported magic {}", magic)),
         }
     }

--- a/cli/src/meta/normalize.rs
+++ b/cli/src/meta/normalize.rs
@@ -15,6 +15,7 @@ impl KnownMeta {
             KnownMeta::SolidityAbiV2 => normalize_json::<SolidityAbi>(data)?,
             KnownMeta::InterpreterCallerMetaV1 => normalize_json::<InterpreterCallerMeta>(data)?,
             KnownMeta::OpV1 => normalize_json::<OpMeta>(data)?,
+            KnownMeta::OptionalMeta => data.to_vec()
         })
     }
 }

--- a/cli/src/meta/normalize.rs
+++ b/cli/src/meta/normalize.rs
@@ -15,7 +15,7 @@ impl KnownMeta {
             KnownMeta::SolidityAbiV2 => normalize_json::<SolidityAbi>(data)?,
             KnownMeta::InterpreterCallerMetaV1 => normalize_json::<InterpreterCallerMeta>(data)?,
             KnownMeta::OpV1 => normalize_json::<OpMeta>(data)?,
-            KnownMeta::OptionalMeta => data.to_vec()
+            KnownMeta::OptionalMetaV1 => data.to_vec()
         })
     }
 }


### PR DESCRIPTION
Introducing new `KnowMagic`  : `OptionalMeta = 0xff0c949e41995247` . 
The intended use is to encoded arbitrary bytes with this magic that will be emitted in events for offchain processes.